### PR TITLE
Fix theme/accent not persisting after app restart

### DIFF
--- a/openspec/changes/fix-theme-persistence/.openspec.yaml
+++ b/openspec/changes/fix-theme-persistence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/fix-theme-persistence/design.md
+++ b/openspec/changes/fix-theme-persistence/design.md
@@ -1,0 +1,29 @@
+## Context
+
+`src/frontend/store/theme.js` writes theme choice to `localStorage` synchronously on every `setTheme()` call. Browser/Chromium `localStorage` backends (leveldb) don't guarantee an immediate disk write on `setItem` — the write is queued and flushed asynchronously by the storage backend.
+
+`src/main.js` currently:
+- `window-all-closed`: calls `app.quit()` then immediately `app.exit(0)` (line 137-138).
+- `before-quit`: force-destroys all `BrowserWindow`s via `win.destroy()` (line 144).
+
+`app.exit(0)` terminates the process immediately without waiting for Electron's normal shutdown sequence (no `will-quit`/`quit` event flow), which is when Chromium flushes pending storage writes for the session partition. `win.destroy()` on the renderer also skips the graceful `close` teardown a webContents would otherwise get. Combined, the last theme write is frequently lost before hitting disk, so next launch falls back to `renderer.js`'s hardcoded default (`"dark"`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Theme selection survives full app restart reliably.
+- Shutdown remains clean — app still quits on `window-all-closed` (non-macOS) without hanging or leaving zombie processes.
+
+**Non-Goals:**
+- Not migrating theme storage off `localStorage` to some other persistence layer (e.g., electron-store, DB). Not needed — root cause is shutdown timing, not the storage mechanism.
+- Not changing renderer-side theme logic in `theme.js`.
+
+## Decisions
+
+- **Remove `app.exit(0)` from `window-all-closed`.** `app.quit()` alone already triggers the standard Electron shutdown sequence, which waits for webContents/session teardown (including storage flush) before the process exits. `app.exit(0)` exists specifically to skip that sequence — appropriate for crash/force-quit paths, not normal quit. Alternative considered: keep `app.exit(0)` but add a delay/flush call before it — rejected as fragile (arbitrary timing) versus just not force-killing.
+- **Change `before-quit` to not force-destroy windows.** Let `app.quit()`'s default behavior close windows normally (fires `close` on each `BrowserWindow`, allowing the renderer/session to unload cleanly) instead of `win.destroy()`, which skips the unload path. Alternative considered: call `session.flushStorageData()` explicitly before destroy — more explicit but adds an extra manual dependency on session internals for what's already the default behavior when quit isn't forced.
+
+## Risks / Trade-offs
+
+- [Removing `app.exit(0)` could theoretically leave the app slower to fully exit under `window-all-closed` if there's a hang in windows closing] → Mitigation: this is standard Electron shutdown; no functional difference expected across platforms already in use (Windows/Linux per `process.platform !== "darwin"` check).
+- [Behavior change is only observable across a real restart, not from static analysis] → Mitigation: manual verification step in tasks.md (set theme, quit, relaunch, confirm retained).

--- a/openspec/changes/fix-theme-persistence/proposal.md
+++ b/openspec/changes/fix-theme-persistence/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Selected theme (light/dark) does not persist after app restart. Root cause: `src/main.js` kills the process before Chromium flushes `localStorage` to disk on quit, so the last `setTheme()` write is lost and the app falls back to the hardcoded default (`"dark"`) on next launch.
+
+## What Changes
+
+- Remove `app.exit(0)` from the `window-all-closed` handler in `src/main.js` — let `app.quit()` alone drive shutdown so Electron flushes storage before the process dies.
+- Change `before-quit` handler to stop force-destroying windows (`win.destroy()`) before storage flush completes; let the normal quit sequence close windows.
+- No renderer-side changes — `src/frontend/store/theme.js` and `src/renderer.js` read/write `localStorage` correctly already.
+
+## Capabilities
+
+### New Capabilities
+- `theme-persistence`: user's selected theme (light/dark) is durably saved and restored across app restarts.
+
+### Modified Capabilities
+(none — no existing specs cover app shutdown/theme behavior)
+
+## Impact
+
+- `src/main.js`: `window-all-closed` and `before-quit` handlers.
+- No schema, IPC, or renderer API changes.
+- No breaking changes.

--- a/openspec/changes/fix-theme-persistence/specs/theme-persistence/spec.md
+++ b/openspec/changes/fix-theme-persistence/specs/theme-persistence/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Theme selection persists across app restarts
+The system SHALL retain the user's last-selected theme (`light` or `dark`) across a full application quit and relaunch.
+
+#### Scenario: User selects a theme then restarts the app
+- **WHEN** the user selects a theme in Settings and then fully quits and relaunches the app
+- **THEN** the app launches with the previously selected theme applied, not the hardcoded default
+
+#### Scenario: App quits via window-all-closed on non-macOS platforms
+- **WHEN** the last window is closed on Windows/Linux, triggering the `window-all-closed` shutdown path
+- **THEN** the app shuts down through the standard Electron quit sequence (no forced `app.exit()`) so pending storage writes are flushed before the process terminates
+
+#### Scenario: No theme ever selected
+- **WHEN** the user has never selected a theme (no saved value)
+- **THEN** the app falls back to system color-scheme preference, or `dark` if unavailable, as before

--- a/openspec/changes/fix-theme-persistence/tasks.md
+++ b/openspec/changes/fix-theme-persistence/tasks.md
@@ -1,0 +1,25 @@
+## 1. Fix shutdown sequence
+
+- [x] 1.1 Remove `app.exit(0)` call from `window-all-closed` handler in `src/main.js` (keep `app.quit()`)
+- [x] 1.2 Change `before-quit` handler in `src/main.js` to stop calling `win.destroy()` on all windows; let default quit sequence close them
+
+## 2. Verify
+
+- [x] 2.1 Run app, switch theme in Settings, fully quit (not just close to tray if applicable), relaunch, confirm theme retained
+- [x] 2.2 Confirm app still exits cleanly on window-all-closed (no hang, no zombie process) on Linux/Windows
+- [x] 2.3 Confirm existing behavior unaffected: no saved theme still falls back to system preference / dark default on first run
+
+## 3. Fix duplicated accent-color implementation (real root cause of reported bug)
+
+Discovered during verification: `TopBar.vue` and `Setting.vue` each kept an independent
+`activeAccent` ref, own `accentColors` list, and own `setAccent()` writing the same
+`localStorage` key, with mismatched hardcoded fallback colors (`#3498db` vs `#8e44ad`).
+Neither applied the saved accent before first paint, so the CSS-default accent
+(`#8e44ad`, purple) showed until `TopBar.vue`'s `onMounted` ran (or not at all
+if it hadn't yet / accent was never actually saved to disk).
+
+- [x] 3.1 Create `src/frontend/store/accent.js` (Pinia store, same pattern as `theme.js`) as single source of truth for `accentColor`
+- [x] 3.2 Apply saved accent color pre-mount in `src/renderer.js` (mirrors existing theme flash-prevention)
+- [x] 3.3 Update `Setting.vue` to use `useAccentStore` instead of its own local `activeAccent`/`accentColors`/`setAccent`
+- [x] 3.4 Remove duplicate accent logic from `TopBar.vue` (dead `accentColors`/`activeAccent`, redundant `setAccent`, `onMounted` re-apply)
+- [x] 3.5 Manually verify: pick a non-default accent color, fully quit, relaunch — correct color shown immediately (no purple flash) and correct swatch highlighted in Settings

--- a/src/frontend/components/Setting.vue
+++ b/src/frontend/components/Setting.vue
@@ -83,15 +83,15 @@
                 </div>
                 <div class="color-grid">
                   <div
-                    v-for="color in accentColors"
+                    v-for="color in accentStore.accentColors"
                     :key="color.key"
-                    @click="setAccent(color.value)"
+                    @click="accentStore.setAccent(color.value)"
                     class="color-swatch"
-                    :class="{ active: activeAccent === color.value }"
+                    :class="{ active: accentStore.accentColor === color.value }"
                     :style="{ background: color.value }"
                   >
                     <i
-                      v-if="activeAccent === color.value"
+                      v-if="accentStore.accentColor === color.value"
                       class="fa-solid fa-check"
                     ></i>
                   </div>
@@ -278,6 +278,7 @@
 import { ref, onMounted, computed } from "vue"
 import { useI18n } from "vue-i18n"
 import { useThemeStore } from "../store/theme.js"
+import { useAccentStore } from "../store/accent.js"
 
 const props = defineProps({
   showSettingMenu: {
@@ -288,6 +289,7 @@ const props = defineProps({
 
 const emit = defineEmits(["close"])
 const themeStore = useThemeStore()
+const accentStore = useAccentStore()
 const { locale, t } = useI18n()
 
 const activeTab = ref("appearance")
@@ -295,9 +297,8 @@ const activeTab = ref("appearance")
 // use store for theme
 const isDarkMode = computed(() => themeStore.theme === "dark")
 
-// locale + accent
+// locale
 const currentLocale = ref(localStorage.getItem("locale") || "en")
-const activeAccent = ref(localStorage.getItem("accentColor") || "#3498db") // deafult to blue override here
 
 const tabs = [
   {
@@ -323,17 +324,6 @@ const tabs = [
   },
 ]
 
-const accentColors = [
-  { key: "blue", value: "#3498db" },
-  { key: "purple", value: "#8e44ad" },
-  { key: "green", value: "#27ae60" },
-  { key: "orange", value: "#e67e22" },
-  { key: "pink", value: "#e84393" },
-  { key: "red", value: "#c0392b" },
-  { key: "teal", value: "#1abc9c" },
-  { key: "indigo", value: "#6c5ce7" },
-]
-
 const version = "1.0.1-beta"
 
 const setTheme = (theme) => {
@@ -351,54 +341,12 @@ const setLanguage = (lang) => {
   localStorage.setItem("locale", lang)
 }
 
-// accent
-const setAccent = (color) => {
-  document.documentElement.style.setProperty("--accent", color)
-  document.documentElement.style.setProperty(
-    "--accent-hover",
-    adjustBrightness(color, 1.15)
-  )
-  document.documentElement.style.setProperty(
-    "--hover-bg",
-    hexToRgba(color, 0.2)
-  )
-  localStorage.setItem("accentColor", color)
-  activeAccent.value = color
-}
-
-// utils
-function hexToRgba(hex, alpha = 0.25) {
-  const c = hex.replace("#", "")
-  const r = parseInt(c.substring(0, 2), 16)
-  const g = parseInt(c.substring(2, 4), 16)
-  const b = parseInt(c.substring(4, 6), 16)
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`
-}
-
-function adjustBrightness(hex, factor) {
-  const col = hex.replace("#", "")
-  const r = parseInt(col.substring(0, 2), 16)
-  const g = parseInt(col.substring(2, 4), 16)
-  const b = parseInt(col.substring(4, 6), 16)
-  const newR = Math.min(255, Math.floor(r * factor))
-  const newG = Math.min(255, Math.floor(g * factor))
-  const newB = Math.min(255, Math.floor(b * factor))
-  return `rgb(${newR}, ${newG}, ${newB})`
-}
-
 onMounted(() => {
-  // keep locale and accent initialization here (theme is initialized in store)
+  // keep locale initialization here (theme + accent are initialized in their stores)
   const savedLang = localStorage.getItem("locale")
   if (savedLang) {
     currentLocale.value = savedLang
     locale.value = savedLang
-  }
-
-  const savedColor = localStorage.getItem("accentColor")
-  if (savedColor) {
-    activeAccent.value = savedColor
-    // optionally re-apply CSS variables on mount:
-    setAccent(savedColor)
   }
 })
 </script>

--- a/src/frontend/components/TopBar.vue
+++ b/src/frontend/components/TopBar.vue
@@ -87,13 +87,6 @@ const showDropdown = ref(false)
 const searchStore = useSearchStore()
 const localQuery = ref(searchStore.query)
 
-// Accent color stuff (unchanged)
-const accentColors = [
-  { name: "Purple", value: "#8e44ad" },
-  /* ... */ { name: "Teal", value: "#1abc9c" },
-]
-const activeAccent = ref(localStorage.getItem("accentColor") || "#8e44ad")
-
 // Localize
 const { locale } = useI18n()
 const currentLocale = ref(localStorage.getItem("locale") || "en")
@@ -118,41 +111,6 @@ const toggleLanguage = () => {
 // THEME: expose computed for UI
 const isDarkMode = computed(() => themeStore.theme === "dark")
 const toggleTheme = () => themeStore.toggleTheme()
-
-// Accent color logic unchanged
-const setAccent = (color) => {
-  document.documentElement.style.setProperty("--accent", color)
-  document.documentElement.style.setProperty(
-    "--accent-hover",
-    adjustBrightness(color, 1.15)
-  )
-  document.documentElement.style.setProperty(
-    "--hover-bg",
-    hexToRgba(color, 0.2)
-  )
-  localStorage.setItem("accentColor", color)
-  activeAccent.value = color
-  showDropdown.value = false
-}
-
-// Utils: hexToRgba & adjustBrightness (copy your implementations)
-function hexToRgba(hex, alpha = 0.25) {
-  const c = hex.replace("#", "")
-  const r = parseInt(c.substring(0, 2), 16)
-  const g = parseInt(c.substring(2, 4), 16)
-  const b = parseInt(c.substring(4, 6), 16)
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`
-}
-function adjustBrightness(hex, factor) {
-  const col = hex.replace("#", "")
-  const r = parseInt(col.substring(0, 2), 16)
-  const g = parseInt(col.substring(2, 4), 16)
-  const b = parseInt(col.substring(4, 6), 16)
-  const newR = Math.min(255, Math.floor(r * factor))
-  const newG = Math.min(255, Math.floor(g * factor))
-  const newB = Math.min(255, Math.floor(b * factor))
-  return `rgb(${newR}, ${newG}, ${newB})`
-}
 
 // iconFilter now depends on computed isDarkMode
 const iconFilter = computed(() => ({
@@ -182,10 +140,6 @@ onMounted(() => {
   // language
   const savedLang = localStorage.getItem("locale")
   if (savedLang) setLanguage(savedLang)
-
-  // accent
-  const savedColor = localStorage.getItem("accentColor")
-  if (savedColor) setAccent(savedColor)
 
   document.addEventListener("click", handleClickOutside)
 })

--- a/src/frontend/store/accent.js
+++ b/src/frontend/store/accent.js
@@ -1,0 +1,58 @@
+import { defineStore } from "pinia"
+import { ref } from "vue"
+
+export const accentColors = [
+  { key: "blue", value: "#3498db" },
+  { key: "purple", value: "#8e44ad" },
+  { key: "green", value: "#27ae60" },
+  { key: "orange", value: "#e67e22" },
+  { key: "pink", value: "#e84393" },
+  { key: "red", value: "#c0392b" },
+  { key: "teal", value: "#1abc9c" },
+  { key: "indigo", value: "#6c5ce7" },
+]
+
+function hexToRgba(hex, alpha = 0.25) {
+  const c = hex.replace("#", "")
+  const r = parseInt(c.substring(0, 2), 16)
+  const g = parseInt(c.substring(2, 4), 16)
+  const b = parseInt(c.substring(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+function adjustBrightness(hex, factor) {
+  const col = hex.replace("#", "")
+  const r = parseInt(col.substring(0, 2), 16)
+  const g = parseInt(col.substring(2, 4), 16)
+  const b = parseInt(col.substring(4, 6), 16)
+  const newR = Math.min(255, Math.floor(r * factor))
+  const newG = Math.min(255, Math.floor(g * factor))
+  const newB = Math.min(255, Math.floor(b * factor))
+  return `rgb(${newR}, ${newG}, ${newB})`
+}
+
+export const useAccentStore = defineStore("accent", () => {
+  const accentColor = ref(localStorage.getItem("accentColor") || "#3498db")
+
+  function applyDomAccent(color) {
+    document.documentElement.style.setProperty("--accent", color)
+    document.documentElement.style.setProperty(
+      "--accent-hover",
+      adjustBrightness(color, 1.15)
+    )
+    document.documentElement.style.setProperty(
+      "--hover-bg",
+      hexToRgba(color, 0.2)
+    )
+  }
+
+  function setAccent(color) {
+    accentColor.value = color
+    localStorage.setItem("accentColor", color)
+    applyDomAccent(color)
+  }
+
+  applyDomAccent(accentColor.value)
+
+  return { accentColor, accentColors, setAccent }
+})

--- a/src/main.js
+++ b/src/main.js
@@ -135,11 +135,9 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     log.info("main :: All windows closed - quitting app")
     app.quit()
-    app.exit(0)
   }
 })
 
 app.on("before-quit", () => {
-  log.info("main :: App quitting - cleaning up windows")
-  BrowserWindow.getAllWindows().forEach((win) => win.destroy())
+  log.info("main :: App quitting")
 })

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -2,6 +2,12 @@
 const savedTheme = localStorage.getItem("theme") || "dark"
 document.documentElement.setAttribute("data-theme", savedTheme)
 
+// set accent color before Vue app mounts (fixes flash of default accent)
+const savedAccent = localStorage.getItem("accentColor")
+if (savedAccent) {
+  document.documentElement.style.setProperty("--accent", savedAccent)
+}
+
 import { createApp } from "vue"
 import { createPinia } from "pinia"
 import App from "./frontend/App.vue"


### PR DESCRIPTION
app.exit(0) in window-all-closed killed the process before Electron flushed pending localStorage writes to disk, and before-quit's win.destroy() skipped renderer teardown too. Removed both so the normal app.quit() sequence can flush storage before exit.

Also consolidated a duplicated accent-color implementation: TopBar.vue and Setting.vue each held independent state with mismatched fallback colors, and neither applied the saved accent before first paint. New accent.js store (same pattern as theme.js) is now the single source of truth, applied pre-mount in renderer.js.

Resolves #48