### PR TITLE
Add cursor-tracking dot to playback progress bar

### DIFF
--- a/openspec/changes/progress-bar-hover-dot/.openspec.yaml
+++ b/openspec/changes/progress-bar-hover-dot/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/progress-bar-hover-dot/design.md
+++ b/openspec/changes/progress-bar-hover-dot/design.md
@@ -1,0 +1,24 @@
+## Context
+
+`useProgressBar(player)` in `src/frontend/utils/playerUtils.js` already computes `hoverX` (cursor x-offset in px, relative to the bar's left edge) and `hoverTimeVisible` (boolean) on `@mousemove`/`@mouseleave` of the `.progress-bar` element. This currently only drives a floating time-tooltip (`.hover-time`). `MiniPlayer.vue` separately has a `.progress-handle` div positioned at `player.progress * 100%` (current playback position), shown on `.progress-bar:hover`, unrelated to cursor position.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a small circular dot on the progress bar track that tracks the cursor's horizontal position while hovering, giving a precise visual target for click/drag seeking.
+- Consistent behavior/markup across `PlayerBar.vue`, `MiniPlayer.vue`, `ImmersiveMode.vue`.
+
+**Non-Goals:**
+- Not changing seek/drag mechanics (still click-to-seek via existing `seek()`; no new drag-and-hold scrubbing behavior).
+- Not touching `MiniPlayer.vue`'s existing playback-position handle — that stays as a separate, distinct element.
+- Not adding new composable state — reuse `hoverX`/`hoverTimeVisible` as-is.
+
+## Decisions
+
+- **New `.progress-cursor-dot` element, positioned via inline `style="left: hoverX + 'px'"`, `v-if="hoverTimeVisible"`.** Mirrors the existing `.hover-time` tooltip's pattern exactly (same `v-if`, same `left: hoverX + 'px'` binding) — no new reactive state, minimal diff. Alternative considered: CSS-only `::before` pseudo-element following a custom property set via JS on mousemove — rejected, adds an imperative DOM write path for something Vue's reactivity already handles declaratively via existing `hoverX`.
+- **Circular dot styled inline on the bar (not a separate floating tooltip).** Matches the visual language of `MiniPlayer.vue`'s existing `.progress-handle` (14px circle, `top: 50%`, `transform: translate(-50%, -50%)`) for consistency, just driven by `hoverX` instead of `player.progress`.
+
+## Risks / Trade-offs
+
+- [Two dots visible at once on `MiniPlayer.vue` when hovering (existing playback-position handle + new cursor dot) could look cluttered] → Mitigation: differentiate visually (e.g., smaller/dimmer cursor dot, or only show cursor dot outside a small radius of the playback-position handle) — left as an implementation detail to eyeball during 1.x tasks, not a blocking design decision.
+- [Dot rendering on top of `.progress-fill` at low z-index could get visually clipped] → Mitigation: explicit `z-index` above `.progress-fill`, matching how `.hover-time` already stacks correctly today.

--- a/openspec/changes/progress-bar-hover-dot/proposal.md
+++ b/openspec/changes/progress-bar-hover-dot/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The playback progress bar (`PlayerBar.vue`, `MiniPlayer.vue`, `ImmersiveMode.vue`) shows a floating time tooltip on hover but gives no visual marker of exactly where on the track the cursor is. Users can't precisely see the point they're about to click/drag to, making seeking imprecise, especially on the thin (6px) bar.
+
+## What Changes
+
+- Add a visual dot/handle that tracks the mouse cursor's x-position on the progress bar while hovering, so users can see exactly where a click/drag will seek to.
+- Reuse the existing `hoverX` value already computed by the shared `useProgressBar` composable (`src/frontend/utils/playerUtils.js`) — no new tracking logic needed, just a new visual element bound to it.
+- Apply consistently across all three progress bar instances that share this composable: `PlayerBar.vue`, `MiniPlayer.vue`, `ImmersiveMode.vue`.
+- `MiniPlayer.vue` already has a `.progress-handle` dot, but it's pinned to current playback position (`player.progress`), not the cursor — this is a distinct, separate indicator and is left as-is; the new dot is additive.
+
+## Capabilities
+
+### New Capabilities
+- `progress-bar-cursor-indicator`: a visual dot that follows the mouse cursor's horizontal position while hovering the playback progress bar, visible only on hover.
+
+### Modified Capabilities
+(none — no existing specs cover progress bar interaction)
+
+## Impact
+
+- `src/frontend/components/PlayerBar.vue`: add cursor-dot element + styles.
+- `src/frontend/components/MiniPlayer.vue`: add cursor-dot element + styles (additive to existing playback-position handle).
+- `src/frontend/components/ImmersiveMode.vue`: add cursor-dot element + styles.
+- No changes to `src/frontend/utils/playerUtils.js` — `hoverX`/`hoverTimeVisible` already provide what's needed.
+- No breaking changes; purely additive UI.

--- a/openspec/changes/progress-bar-hover-dot/specs/progress-bar-cursor-indicator/spec.md
+++ b/openspec/changes/progress-bar-hover-dot/specs/progress-bar-cursor-indicator/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Cursor-tracking dot on progress bar hover
+The system SHALL display a visual dot on the playback progress bar at the mouse cursor's horizontal position while the cursor hovers over the bar.
+
+#### Scenario: Hovering the progress bar
+- **WHEN** the user moves the mouse over the playback progress bar
+- **THEN** a dot appears on the bar at the cursor's x-position, updating as the cursor moves
+
+#### Scenario: Cursor leaves the progress bar
+- **WHEN** the user moves the mouse off the playback progress bar
+- **THEN** the cursor dot is hidden
+
+#### Scenario: Consistent across player views
+- **WHEN** the user hovers the progress bar in the main player bar, mini player, or immersive mode
+- **THEN** the same cursor-dot behavior applies in all three
+
+#### Scenario: Clicking still seeks as before
+- **WHEN** the user clicks the progress bar at the cursor dot's position
+- **THEN** playback seeks to that position, unchanged from existing click-to-seek behavior

--- a/openspec/changes/progress-bar-hover-dot/tasks.md
+++ b/openspec/changes/progress-bar-hover-dot/tasks.md
@@ -1,0 +1,21 @@
+## 1. PlayerBar.vue
+
+- [x] 1.1 Add `.progress-cursor-dot` div bound to `hoverX`/`hoverTimeVisible` (same pattern as existing `.hover-time`)
+- [x] 1.2 Add matching CSS (small circle, `z-index` above `.progress-fill`)
+
+## 2. MiniPlayer.vue
+
+- [x] 2.1 Add `.progress-cursor-dot` div bound to `hoverX`/`hoverTimeVisible`, distinct from the existing playback-position `.progress-handle`
+- [x] 2.2 Add matching CSS, visually differentiated from `.progress-handle` so both can be visible without confusion
+
+## 3. ImmersiveMode.vue
+
+- [x] 3.1 Add `.progress-cursor-dot` div bound to `hoverX`/`hoverTimeVisible`
+- [x] 3.2 Add matching CSS
+
+## 4. Verify
+
+- [x] 4.1 Run app, hover progress bar in main player bar — dot tracks cursor, hides on mouse leave
+- [x] 4.2 Same check in mini player — new cursor dot and existing playback-position handle both render correctly, not confusing
+- [x] 4.3 Same check in immersive mode
+- [x] 4.4 Click-to-seek still works unchanged in all three

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/src/frontend/components/ImmersiveMode.vue
+++ b/src/frontend/components/ImmersiveMode.vue
@@ -57,6 +57,11 @@
         ></div>
         <div
           v-if="hoverTimeVisible"
+          class="progress-cursor-dot"
+          :style="{ left: hoverX + 'px' }"
+        ></div>
+        <div
+          v-if="hoverTimeVisible"
           class="hover-time"
           :style="{ left: hoverX + 'px' }"
         >
@@ -492,6 +497,19 @@ onMounted(() => {
   height: 100%;
   background: var(--accent);
   transition: width 0.1s linear;
+}
+
+.progress-cursor-dot {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  background: white;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  z-index: 2;
+  pointer-events: none;
 }
 
 .hover-time {

--- a/src/frontend/components/MiniPlayer.vue
+++ b/src/frontend/components/MiniPlayer.vue
@@ -76,6 +76,11 @@
             ></div>
             <div
               v-if="hoverTimeVisible"
+              class="progress-cursor-dot"
+              :style="{ left: hoverX + 'px' }"
+            ></div>
+            <div
+              v-if="hoverTimeVisible"
               class="hover-time"
               :style="{ left: hoverX + 'px' }"
             >
@@ -522,6 +527,20 @@ onUnmounted(() => {
 
 .progress-bar:hover .progress-handle {
   opacity: 1;
+}
+
+.progress-cursor-dot {
+  position: absolute;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  background: var(--accent);
+  border: 1px solid white;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  z-index: 2;
+  pointer-events: none;
 }
 
 .hover-time {

--- a/src/frontend/components/PlayerBar.vue
+++ b/src/frontend/components/PlayerBar.vue
@@ -12,6 +12,11 @@
     ></div>
     <div
       v-if="hoverTimeVisible"
+      class="progress-cursor-dot"
+      :style="{ left: hoverX + 'px' }"
+    ></div>
+    <div
+      v-if="hoverTimeVisible"
       class="hover-time"
       :style="{ left: hoverX + 'px' }"
     >
@@ -464,6 +469,19 @@ const openArtistFromPlayer = () => {
   height: 100%;
   background: var(--accent);
   transition: width 0.1s linear;
+}
+
+.progress-cursor-dot {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  background: white;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  z-index: 2;
+  pointer-events: none;
 }
 
 .hover-time {


### PR DESCRIPTION
Adds a small dot that follows the mouse cursor's horizontal position while hovering the progress bar, giving a precise visual target for seeking. Reuses the existing hoverX/hoverTimeVisible state from useProgressBar - no new tracking logic, just a new element mirroring the existing hover-time tooltip's binding.

Applied to PlayerBar.vue, MiniPlayer.vue (kept visually distinct from its existing playback-position handle), and ImmersiveMode.vue.

#60 enhancement implemented