### PR TITLE
Add Last.fm scrobbling with user-supplied API credentials

### DIFF
--- a/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/design.md
+++ b/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/design.md
@@ -1,0 +1,56 @@
+## Context
+
+EchoVault is an Electron + Vue app. Playback lives entirely in the renderer (`src/frontend/store/player.js`), driven by Web Audio API (`AudioBufferSourceNode`, not `<audio>`), with `currentTrack`, `progress` (0–1), `duration`, and `currentTime` in Pinia state, refreshed by `startProgressUpdater()`. All existing user prefs (theme, locale, `fetchLyricsOnline`) live in renderer `localStorage`. All external network calls (`lrclibClient.js`) happen in the **main** process and are invoked via IPC (`tracks:get-lyrics`), following the pattern in `src/backend/main/tracks.js` / `src/preload.js`. There is no DB `settings` table and no existing OAuth/external-account flow, deep-link protocol handling, or secret storage in the app.
+
+Last.fm's scrobbling API (`ws.audioscrobbler.com/2.0/`) requires:
+- A registered API key + shared secret per **application** (not per user).
+- Desktop auth flow: `auth.getToken` (unauthenticated) → user visits `https://www.last.fm/api/auth/?api_key=...&token=...` to grant access → `auth.getSession` (signed with the token) returns a permanent `session key` for that user.
+- All write calls (`track.updateNowPlaying`, `track.scrobble`) must be signed: sort params alphabetically, concatenate `key+value` pairs + the secret, MD5 hash it into `api_sig`.
+- Scrobble rule: only scrobble tracks longer than 30s, once at least 50% has played or 4 minutes have played, whichever comes first.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let a user connect their Last.fm account from Settings and see connection status.
+- Send now-playing + scrobble updates automatically for local playback, matching Last.fm's official scrobble rule.
+- Keep the session key out of the renderer and off disk in plaintext.
+- Don't lose scrobbles just because the network hiccups.
+
+**Non-Goals:**
+- No custom URL-scheme deep link to auto-detect authorization completion — the user clicks "Connect", authorizes in the browser, then clicks "I've authorized" in-app to complete the flow. Simpler, and this app doesn't already register OS-level protocol handling for callbacks (the existing `echovault://` scheme is a buffer protocol for local images only).
+- No support for other scrobbling services (Libre.fm, ListenBrainz).
+- No multi-account / account switching.
+- No scrobbling for tracks the user seeks around in unpredictably beyond the standard rule — we track cumulative played time, not "did they finish it."
+
+## Decisions
+
+**1. Auth flow: manual confirm, not a local callback server or deep link.**
+`shell.openExternal()` opens the Last.fm authorize URL; a "I've authorized, continue" button in Settings triggers `auth.getSession`. Alternative considered: register `app.setAsDefaultProtocolClient` for a callback deep link — rejected as more moving parts (single-instance lock changes, OS registration, dev-mode quirks) for a one-time action the user does rarely.
+
+**2. Credential storage: `safeStorage`-encrypted file in `userData`, main process only.**
+`src/backend/main/lastfm.js` owns a `lastfm-auth.json` file (`{ encryptedApiKey, encryptedApiSecret, encryptedSessionKey, username, scrobblingEnabled }`, fields populated incrementally as the user saves credentials then completes auth) written with `safeStorage.encryptString`/`decryptString`. The renderer never receives the raw secret or session key — only status (`{hasCredentials, connected, username, scrobblingEnabled}`) over IPC. This is stricter than the existing `localStorage` pattern used for theme/locale, which is deliberate: those are non-sensitive UI prefs; a Last.fm API secret and session key are credentials.
+
+**3. Now-playing / scrobble triggers live in the main process, driven by IPC calls from the player store.**
+The renderer already knows exactly when a track starts (`setTrack`) and tracks `currentTime`/`duration` every tick (`startProgressUpdater`). Reuse that instead of duplicating a playback clock in main:
+- `setTrack()` → after successful `playTrack`, call `window.api.lastfmNowPlaying({artist, title, album, duration})` (fire-and-forget, same pattern as `getLyrics()`).
+- `startProgressUpdater()` gains a one-shot check: once `currentTime >= min(duration/2, 240)` (and `duration > 30`) and a scrobble hasn't been sent for this "play instance," call `window.api.lastfmScrobble({...})`. A per-track-instance flag (reset in `setTrack`) prevents double-scrobbling on seek/replay ticks.
+- Manual seeking backwards before the threshold is fine — the flag only cares about highest `currentTime` reached, matching Last.fm's "half played" intent.
+
+**4. Signing + retry queue live in `src/backend/utils/lastfmClient.js`.**
+Pure functions: `buildSignature(params, secret)` (MD5 via Node's `crypto`), `getToken`, `getSession`, `updateNowPlaying`, `scrobble`. Failed scrobbles (network error / 5xx) are appended to a small JSON queue file (`lastfm-queue.json`, capped at 50 entries — oldest dropped past that, this is a local convenience queue, not a durable log) and retried opportunistically on the next successful scrobble/now-playing call or app start.
+
+**5. API key/secret are user-supplied, not embedded in the build.**
+Reversed from the original plan: Last.fm requires a key+secret pair registered to *an application*, and shipping one app-wide secret embedded in the EchoVault binary means every install shares one app identity — anyone can extract it from the binary and impersonate the app, and it hard-couples scrobbling to whoever controls the build's env vars. Instead, each user registers their own free Last.fm API application (last.fm/api/account/create — a two-field form, no approval wait) and pastes their key+secret into Settings before connecting. `lastfmClient.js` functions take `{apiKey, apiSecret}` as an explicit argument instead of reading `process.env`; `main/lastfm.js` stores them `safeStorage`-encrypted in the same `lastfm-auth.json` as the session key. This removes the whole "is this build configured" concept — there's no privileged build-time state, just "has this user saved credentials yet."
+
+Alternative considered: keep one app-wide key via env var (original design) — rejected per the above; also considered a public shared key baked into source like `lrclibClient.js`'s `USER_AGENT` — rejected because unlike a user-agent string, this secret is used to *sign* write requests, so leaking it lets anyone scrobble as "EchoVault."
+
+## Risks / Trade-offs
+
+- **[Risk]** User clicks "I've authorized" before actually approving on last.fm.com → `auth.getSession` returns an error. **Mitigation**: show a toast with the error and let them retry; no partial state is persisted until `getSession` succeeds.
+- **[Risk]** App closed/crashes mid-track → scrobble threshold never fires for that play. **Mitigation**: accepted — matches how most desktop scrobblers behave; not worth persisting playback position across restarts for this.
+- **[Risk]** Retry queue grows if the user is offline for a long time. **Mitigation**: capped at 50 entries (oldest dropped) — acceptable data loss for a local convenience feature, not a sync-critical system.
+- **[Trade-off]** Every user must register their own Last.fm API application before connecting (a couple of form fields on last.fm, no approval wait) — more friction than "just click connect," but avoids embedding a shared secret in the binary. **Mitigation**: Settings shows a direct link to the registration page next to the key/secret fields.
+
+## Open Questions
+
+- None blocking — if the user wants multi-account or Libre.fm/ListenBrainz support later, that's a separate change.

--- a/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/proposal.md
+++ b/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+EchoVault tracks local play counts but has no way to contribute listens to a user's Last.fm profile. Last.fm scrobbling is a widely expected feature in music players — users want their local listening history reflected on their public/social Last.fm profile, and Last.fm-driven recommendations/stats depend on receiving scrobbles. Right now the only account-like setting in the app is local (theme, locale, lyrics toggle); there is no concept of connecting an external service.
+
+## What Changes
+
+- Add a Last.fm account connection flow: user clicks "Connect" in Settings, the app opens Last.fm's web authorization page in the user's default browser, and the user confirms back in-app once they've approved access.
+- Add a "Scrobbling" section to Settings (new tab or under Audio) showing connection status (connected as `<username>` / not connected), a Connect/Disconnect button, and a toggle to enable/disable scrobbling once connected.
+- Persist the Last.fm session key encrypted at rest (Electron `safeStorage`) in a main-process-owned file under `userData` — never expose the raw session key to the renderer.
+- Send a "now playing" update to Last.fm when a track starts playing (if connected and enabled).
+- Send a scrobble to Last.fm once a track passes the official scrobble threshold (played for at least half its duration or 4 minutes, whichever is lower, and duration > 30s), matching Last.fm's scrobbling rules.
+- Queue scrobbles that fail (offline/API error) and retry them so plays aren't silently lost.
+- Let each user save their own Last.fm API key/secret in Settings (from an application they register free at last.fm/api/account/create) instead of embedding one app-wide key in the build — avoids shipping a shared signing secret inside the binary.
+
+## Capabilities
+
+### New Capabilities
+- `lastfm-scrobbling`: Connecting/disconnecting a Last.fm account from Settings, and automatically sending now-playing updates and scrobbles for played tracks according to Last.fm's scrobbling rules.
+
+### Modified Capabilities
+- (none — no existing specs cover settings or playback scrobbling)
+
+## Impact
+
+- **Frontend**: `src/frontend/components/Setting.vue` (new Scrobbling section/tab), `src/frontend/store/player.js` (hook now-playing/scrobble triggers into existing play/progress lifecycle), new `src/frontend/store/lastfm.js` (connection state).
+- **Backend (main process)**: new `src/backend/main/lastfm.js` (IPC handlers: connect, poll-auth, disconnect, get-status, now-playing, scrobble), new `src/backend/utils/lastfmClient.js` (signed API calls, MD5 signing, retry queue).
+- **Preload**: `src/preload.js` — expose `lastfm:*` IPC bridge methods.
+- **Persistence**: new encrypted credentials file in `app.getPath("userData")` (via `safeStorage`); no DB schema change needed.
+- **i18n**: `src/locales/en.json`, `src/locales/ja.json` — new settings strings.
+- **Dependencies**: none new — Node's built-in `fetch` and `crypto` (for MD5 signing) cover all API needs.

--- a/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/specs/lastfm-scrobbling/spec.md
+++ b/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/specs/lastfm-scrobbling/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Save Last.fm API Credentials
+The system SHALL let a user save their own Last.fm API key and secret (from an application they registered at last.fm) before connecting an account, and SHALL NOT ship or require an app-wide embedded key.
+
+#### Scenario: User saves credentials
+- **WHEN** the user enters an API key and secret in Settings and clicks Save
+- **THEN** the app stores both encrypted and shows the Connect option
+
+#### Scenario: No credentials saved yet
+- **WHEN** the user opens the Scrobbling section without having saved an API key/secret
+- **THEN** Settings shows the key/secret input form (with a link to register an app on last.fm) instead of a Connect button
+
+### Requirement: Connect Last.fm Account
+The system SHALL allow a user to connect their Last.fm account from the Settings page via Last.fm's standard desktop auth flow (token request, browser authorization, session key exchange), using the user's saved API key/secret.
+
+#### Scenario: User connects successfully
+- **WHEN** the user has saved API credentials, clicks "Connect" in Settings, authorizes the app on last.fm.com, and clicks "I've authorized" in the app
+- **THEN** the app exchanges the token for a session key, stores it encrypted, and Settings shows "Connected as `<username>`"
+
+#### Scenario: User confirms before authorizing
+- **WHEN** the user clicks "I've authorized" without having granted access on last.fm.com
+- **THEN** the app shows an error toast and remains in the "not connected" state
+
+### Requirement: Disconnect Last.fm Account
+The system SHALL allow a connected user to disconnect their Last.fm account, deleting the stored session key while keeping the saved API key/secret so the user isn't forced to re-enter them to reconnect.
+
+#### Scenario: User disconnects
+- **WHEN** a connected user clicks "Disconnect" in Settings
+- **THEN** the app deletes the stored encrypted session key and username, Settings shows "Not connected", and the saved API key/secret remain so Connect works immediately
+
+### Requirement: Enable/Disable Scrobbling
+The system SHALL let a connected user toggle scrobbling on or off independently of the account connection.
+
+#### Scenario: Scrobbling disabled while connected
+- **WHEN** a connected user turns the scrobbling toggle off and then plays a track
+- **THEN** no now-playing update or scrobble is sent for that playback
+
+### Requirement: Send Now-Playing Updates
+The system SHALL send a "now playing" update to Last.fm when a track starts playing, if the user is connected and scrobbling is enabled.
+
+#### Scenario: Track starts playing
+- **WHEN** a connected, scrobbling-enabled user starts playback of a track with known artist and title
+- **THEN** the app sends a `track.updateNowPlaying` request with the track's artist, title, album, and duration
+
+#### Scenario: Missing required metadata
+- **WHEN** a track has no artist or title metadata
+- **THEN** the app does not send a now-playing update or scrobble for that track
+
+### Requirement: Scrobble Played Tracks
+The system SHALL scrobble a track to Last.fm once it has been played past the Last.fm threshold: at least 50% of its duration or 4 minutes, whichever is lower, and only for tracks longer than 30 seconds.
+
+#### Scenario: Track played past threshold
+- **WHEN** a connected, scrobbling-enabled user plays a 3-minute track to the 90-second mark
+- **THEN** the app sends exactly one `track.scrobble` request for that track
+
+#### Scenario: Track shorter than 30 seconds
+- **WHEN** a track's duration is 20 seconds
+- **THEN** the app never scrobbles that track regardless of how much of it plays
+
+#### Scenario: User skips before threshold
+- **WHEN** a user skips to the next track before reaching the scrobble threshold
+- **THEN** no scrobble is sent for the skipped track
+
+#### Scenario: Re-playing the same track
+- **WHEN** a track is scrobbled and then played again from the start
+- **THEN** the app scrobbles it again once the threshold is reached for the new play
+
+### Requirement: Retry Failed Scrobbles
+The system SHALL retry now-playing/scrobble requests that fail due to network or server errors, without blocking playback.
+
+#### Scenario: Scrobble fails while offline
+- **WHEN** a scrobble request fails because the device is offline
+- **THEN** the app queues the scrobble locally and retries it on the next successful network request, without interrupting playback
+
+### Requirement: Credential Storage
+The system SHALL store the Last.fm API key, API secret, and session key encrypted at rest and SHALL NOT expose any of them to the renderer process.
+
+#### Scenario: Renderer requests connection status
+- **WHEN** the Settings UI asks for the current Last.fm connection state
+- **THEN** the app returns only `{hasCredentials, connected, username, scrobblingEnabled}` — never the API secret or session key

--- a/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/tasks.md
+++ b/openspec/changes/archive/2026-07-07-add-lastfm-scrobbling/tasks.md
@@ -1,0 +1,52 @@
+## 1. Client & Signing Utility
+
+- [x] 1.1 Create `src/backend/utils/lastfmClient.js` with `buildSignature(params, secret)` using Node `crypto` MD5, and `LASTFM_API_KEY`/`LASTFM_API_SECRET` read from `process.env`
+- [x] 1.2 Implement `getToken()`, `getSession(token)`, `updateNowPlaying(sessionKey, track)`, `scrobble(sessionKey, track, timestamp)` against `https://ws.audioscrobbler.com/2.0/`
+- [x] 1.3 Implement a capped (50-entry) JSON-file-backed retry queue for failed now-playing/scrobble calls, with a `flushQueue()` retried opportunistically on the next successful call
+- [x] 1.4 Add a test script (`test_lastfmClient.mjs`, matching `test_lrclibClient.mjs` conventions) covering signature building and threshold/queue logic
+
+## 2. Credential Storage & Main-Process Handlers
+
+- [x] 2.1 Create `src/backend/main/lastfm.js` with a `readAuthFile()`/`writeAuthFile()` pair using `safeStorage.encryptString`/`decryptString` against a `lastfm-auth.json` file in `app.getPath("userData")`
+- [x] 2.2 Register IPC handlers: `lastfm:connect` (getToken + open external auth URL), `lastfm:confirm-auth` (getSession + persist), `lastfm:disconnect` (delete auth file), `lastfm:get-status` (`{configured, connected, username, scrobblingEnabled}`), `lastfm:set-enabled`
+- [x] 2.3 Register IPC handlers: `lastfm:now-playing`, `lastfm:scrobble` — no-op silently if not connected or scrobbling disabled
+- [x] 2.4 Wire `registerLastfmHandlers(mainWindow, db)` into `src/backend/main/ipcHandlers.js`
+
+## 3. Preload Bridge
+
+- [x] 3.1 Add `lastfm*` methods to `src/preload.js` (`connect`, `confirmAuth`, `disconnect`, `getStatus`, `setEnabled`, `nowPlaying`, `scrobble`)
+
+## 4. Playback Hooks
+
+- [x] 4.1 In `src/frontend/store/player.js`, add a `_scrobbled` per-play flag reset in `setTrack()`
+- [x] 4.2 In `setTrack()`, after successful `playTrack`, fire-and-forget `window.api.lastfmNowPlaying({artist, title, album, duration})`
+- [x] 4.3 In `startProgressUpdater()`, check the scrobble threshold (`currentTime >= Math.min(duration / 2, 240)` and `duration > 30`) each tick; when crossed and not yet scrobbled for this play, call `window.api.lastfmScrobble(...)` and set the flag
+- [x] 4.4 Skip both calls when `track.artist` or `track.title` is missing
+
+## 5. Settings UI
+
+- [x] 5.1 Create `src/frontend/store/lastfm.js` (Pinia store) wrapping `window.api.lastfm*`, exposing `{configured, connected, username, scrobblingEnabled}` and `connect()/confirmAuth()/disconnect()/toggleEnabled()`
+- [x] 5.2 Add a "Scrobbling" setting group to `src/frontend/components/Setting.vue` (Audio tab or new tab): connect/disconnect button, connected-as-username display, enable/disable toggle, and an "unavailable" state when `configured` is false
+- [x] 5.3 Add the "I've authorized, continue" confirm step in the UI after clicking Connect
+- [x] 5.4 Add new i18n strings to `src/locales/en.json` and `src/locales/ja.json`
+
+## 6. Build Config
+
+- [x] 6.1 Document `LASTFM_API_KEY`/`LASTFM_API_SECRET` env vars needed for the build (README or `.env.example`) and confirm they're available to the main process at runtime via existing Vite/Forge env handling
+
+## 7. Verification
+
+- [x] 7.1 Manually verify: connect flow end-to-end against a real Last.fm account, now-playing appears on the Last.fm profile, scrobble appears after threshold, disconnect clears state, toggle off stops scrobbles
+- [x] 7.2 Verify offline scrobble is queued and flushed once connectivity returns
+
+## 8. User-Supplied API Credentials (replaces build-time env from group 6)
+
+- [x] 8.1 Refactor `src/backend/utils/lastfmClient.js`: `getToken`, `getSession`, `updateNowPlaying`, `scrobble` (and internal `request`) take `{apiKey, apiSecret}` as an explicit argument instead of reading `process.env`; remove `getCredentials()`/`isConfigured()`
+- [x] 8.2 Refactor `src/backend/main/lastfm.js`: store `encryptedApiKey`/`encryptedApiSecret` in `lastfm-auth.json` alongside the session fields; add a `lastfm:save-credentials` handler; `connect`/`confirm-auth`/`now-playing`/`scrobble` read the stored key/secret instead of env; `disconnect` clears only the session key + username, keeping saved credentials
+- [x] 8.3 Add `lastfmSaveCredentials(apiKey, apiSecret)` to `src/preload.js`
+- [x] 8.4 Update `src/frontend/store/lastfm.js`: replace `configured` with `hasCredentials`, add `saveCredentials(apiKey, apiSecret)`
+- [x] 8.5 Update `src/frontend/components/Setting.vue`: replace the "unavailable" badge with an API key/secret input form (shown when `!hasCredentials`) linking to last.fm/api/account/create; Connect button shows once credentials are saved
+- [x] 8.6 Update i18n (`en.json`/`ja.json`): drop `unavailable`, add `apiKeyLabel`, `apiSecretLabel`, `credentialsHint`, `saveAndConnect`
+- [x] 8.7 Remove build-time env plumbing: revert the `.env` load in `src/main.js`, delete `.env.example`, remove the "Last.fm Scrobbling (optional)" README section
+- [x] 8.8 Update `test_lastfmClient.mjs` for the new `{apiKey, apiSecret}`-argument function signatures
+- [x] 8.9 Re-run the `npm run start` smoke test after the refactor

--- a/openspec/specs/lastfm-scrobbling/spec.md
+++ b/openspec/specs/lastfm-scrobbling/spec.md
@@ -1,0 +1,87 @@
+# lastfm-scrobbling
+
+## Purpose
+
+Let users connect their own Last.fm account to EchoVault so their listening activity is scrobbled to Last.fm, using their own registered API credentials (no app-wide embedded key), with credentials stored encrypted and never exposed to the renderer process.
+
+## Requirements
+
+### Requirement: Save Last.fm API Credentials
+The system SHALL let a user save their own Last.fm API key and secret (from an application they registered at last.fm) before connecting an account, and SHALL NOT ship or require an app-wide embedded key.
+
+#### Scenario: User saves credentials
+- **WHEN** the user enters an API key and secret in Settings and clicks Save
+- **THEN** the app stores both encrypted and shows the Connect option
+
+#### Scenario: No credentials saved yet
+- **WHEN** the user opens the Scrobbling section without having saved an API key/secret
+- **THEN** Settings shows the key/secret input form (with a link to register an app on last.fm) instead of a Connect button
+
+### Requirement: Connect Last.fm Account
+The system SHALL allow a user to connect their Last.fm account from the Settings page via Last.fm's standard desktop auth flow (token request, browser authorization, session key exchange), using the user's saved API key/secret.
+
+#### Scenario: User connects successfully
+- **WHEN** the user has saved API credentials, clicks "Connect" in Settings, authorizes the app on last.fm.com, and clicks "I've authorized" in the app
+- **THEN** the app exchanges the token for a session key, stores it encrypted, and Settings shows "Connected as `<username>`"
+
+#### Scenario: User confirms before authorizing
+- **WHEN** the user clicks "I've authorized" without having granted access on last.fm.com
+- **THEN** the app shows an error toast and remains in the "not connected" state
+
+### Requirement: Disconnect Last.fm Account
+The system SHALL allow a connected user to disconnect their Last.fm account, deleting the stored session key while keeping the saved API key/secret so the user isn't forced to re-enter them to reconnect.
+
+#### Scenario: User disconnects
+- **WHEN** a connected user clicks "Disconnect" in Settings
+- **THEN** the app deletes the stored encrypted session key and username, Settings shows "Not connected", and the saved API key/secret remain so Connect works immediately
+
+### Requirement: Enable/Disable Scrobbling
+The system SHALL let a connected user toggle scrobbling on or off independently of the account connection.
+
+#### Scenario: Scrobbling disabled while connected
+- **WHEN** a connected user turns the scrobbling toggle off and then plays a track
+- **THEN** no now-playing update or scrobble is sent for that playback
+
+### Requirement: Send Now-Playing Updates
+The system SHALL send a "now playing" update to Last.fm when a track starts playing, if the user is connected and scrobbling is enabled.
+
+#### Scenario: Track starts playing
+- **WHEN** a connected, scrobbling-enabled user starts playback of a track with known artist and title
+- **THEN** the app sends a `track.updateNowPlaying` request with the track's artist, title, album, and duration
+
+#### Scenario: Missing required metadata
+- **WHEN** a track has no artist or title metadata
+- **THEN** the app does not send a now-playing update or scrobble for that track
+
+### Requirement: Scrobble Played Tracks
+The system SHALL scrobble a track to Last.fm once it has been played past the Last.fm threshold: at least 50% of its duration or 4 minutes, whichever is lower, and only for tracks longer than 30 seconds.
+
+#### Scenario: Track played past threshold
+- **WHEN** a connected, scrobbling-enabled user plays a 3-minute track to the 90-second mark
+- **THEN** the app sends exactly one `track.scrobble` request for that track
+
+#### Scenario: Track shorter than 30 seconds
+- **WHEN** a track's duration is 20 seconds
+- **THEN** the app never scrobbles that track regardless of how much of it plays
+
+#### Scenario: User skips before threshold
+- **WHEN** a user skips to the next track before reaching the scrobble threshold
+- **THEN** no scrobble is sent for the skipped track
+
+#### Scenario: Re-playing the same track
+- **WHEN** a track is scrobbled and then played again from the start
+- **THEN** the app scrobbles it again once the threshold is reached for the new play
+
+### Requirement: Retry Failed Scrobbles
+The system SHALL retry now-playing/scrobble requests that fail due to network or server errors, without blocking playback.
+
+#### Scenario: Scrobble fails while offline
+- **WHEN** a scrobble request fails because the device is offline
+- **THEN** the app queues the scrobble locally and retries it on the next successful network request, without interrupting playback
+
+### Requirement: Credential Storage
+The system SHALL store the Last.fm API key, API secret, and session key encrypted at rest and SHALL NOT expose any of them to the renderer process.
+
+#### Scenario: Renderer requests connection status
+- **WHEN** the Settings UI asks for the current Last.fm connection state
+- **THEN** the app returns only `{hasCredentials, connected, username, scrobblingEnabled}` — never the API secret or session key

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "echovault",
   "productName": "EchoVault",
-  "version": "1.0.1-beta",
+  "version": "1.1.0-beta",
   "description": "A modern music player for lossless audio formats",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/src/backend/main/ipcHandlers.js
+++ b/src/backend/main/ipcHandlers.js
@@ -5,6 +5,7 @@ import { registerPlayerHandlers } from "./player"
 import { registerSearchHandlers } from "./search"
 import { registerWindowHandlers } from "./window"
 import { registerPlaylistHandlers } from "./playlists"
+import { registerLastfmHandlers } from "./lastfm"
 
 export function registerAllHandlers(mainWindow, db) {
   registerArtistHandlers(db)
@@ -14,4 +15,5 @@ export function registerAllHandlers(mainWindow, db) {
   registerSearchHandlers(mainWindow, db)
   registerWindowHandlers(mainWindow)
   registerPlaylistHandlers(mainWindow, db)
+  registerLastfmHandlers()
 }

--- a/src/backend/main/lastfm.js
+++ b/src/backend/main/lastfm.js
@@ -1,0 +1,158 @@
+import { ipcMain, shell, safeStorage, app } from "electron"
+import fs from "fs"
+import path from "path"
+import {
+  getToken,
+  buildAuthUrl,
+  getSession,
+  updateNowPlaying,
+  scrobble,
+  enqueueFailedScrobble,
+  flushQueue,
+} from "../utils/lastfmClient.js"
+
+function getAuthPath() {
+  return path.join(app.getPath("userData"), "lastfm-auth.json")
+}
+
+function getQueuePath() {
+  return path.join(app.getPath("userData"), "lastfm-queue.json")
+}
+
+function decrypt(base64) {
+  return safeStorage.decryptString(Buffer.from(base64, "base64"))
+}
+
+function encrypt(value) {
+  return safeStorage.encryptString(value).toString("base64")
+}
+
+function readAuth() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(getAuthPath(), "utf-8"))
+    return {
+      apiKey: decrypt(raw.encryptedApiKey),
+      apiSecret: decrypt(raw.encryptedApiSecret),
+      sessionKey: raw.encryptedSessionKey ? decrypt(raw.encryptedSessionKey) : null,
+      username: raw.username ?? null,
+      scrobblingEnabled: raw.scrobblingEnabled ?? false,
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeAuth({ apiKey, apiSecret, sessionKey, username, scrobblingEnabled }) {
+  fs.writeFileSync(
+    getAuthPath(),
+    JSON.stringify({
+      encryptedApiKey: encrypt(apiKey),
+      encryptedApiSecret: encrypt(apiSecret),
+      encryptedSessionKey: sessionKey ? encrypt(sessionKey) : null,
+      username: username ?? null,
+      scrobblingEnabled: scrobblingEnabled ?? false,
+    })
+  )
+}
+
+export function registerLastfmHandlers() {
+  let pendingToken = null
+
+  ipcMain.handle("lastfm:get-status", () => {
+    const auth = readAuth()
+    return {
+      hasCredentials: !!auth,
+      connected: !!auth?.sessionKey,
+      username: auth?.username ?? null,
+      scrobblingEnabled: auth?.scrobblingEnabled ?? false,
+    }
+  })
+
+  ipcMain.handle("lastfm:save-credentials", (event, { apiKey, apiSecret }) => {
+    if (!apiKey || !apiSecret) return { ok: false, error: "missing-credentials" }
+    if (!safeStorage.isEncryptionAvailable()) {
+      return { ok: false, error: "secure storage unavailable on this system" }
+    }
+
+    const existing = readAuth()
+    writeAuth({
+      apiKey,
+      apiSecret,
+      sessionKey: existing?.sessionKey,
+      username: existing?.username,
+      scrobblingEnabled: existing?.scrobblingEnabled,
+    })
+    return { ok: true }
+  })
+
+  ipcMain.handle("lastfm:connect", async () => {
+    const auth = readAuth()
+    if (!auth) return { ok: false, error: "no-credentials" }
+
+    const result = await getToken(auth)
+    if (!result.ok) return result
+
+    pendingToken = result.token
+    shell.openExternal(buildAuthUrl(auth, result.token))
+    return { ok: true }
+  })
+
+  ipcMain.handle("lastfm:confirm-auth", async () => {
+    const auth = readAuth()
+    if (!auth) return { ok: false, error: "no-credentials" }
+    if (!pendingToken) return { ok: false, error: "no pending authorization" }
+
+    const result = await getSession(auth, pendingToken)
+    pendingToken = null
+    if (!result.ok) return result
+
+    writeAuth({
+      apiKey: auth.apiKey,
+      apiSecret: auth.apiSecret,
+      sessionKey: result.sessionKey,
+      username: result.username,
+      scrobblingEnabled: true,
+    })
+    return { ok: true, username: result.username }
+  })
+
+  ipcMain.handle("lastfm:disconnect", () => {
+    const auth = readAuth()
+    if (auth) {
+      writeAuth({
+        apiKey: auth.apiKey,
+        apiSecret: auth.apiSecret,
+        sessionKey: null,
+        username: null,
+        scrobblingEnabled: false,
+      })
+    }
+    return { ok: true }
+  })
+
+  ipcMain.handle("lastfm:set-enabled", (event, enabled) => {
+    const auth = readAuth()
+    if (!auth?.sessionKey) return { ok: false, error: "not-connected" }
+    writeAuth({ ...auth, scrobblingEnabled: enabled })
+    return { ok: true }
+  })
+
+  ipcMain.handle("lastfm:now-playing", async (event, track) => {
+    const auth = readAuth()
+    if (!auth?.sessionKey || !auth.scrobblingEnabled || !track?.artist || !track?.title) return
+    await updateNowPlaying(auth, auth.sessionKey, track)
+  })
+
+  ipcMain.handle("lastfm:scrobble", async (event, track) => {
+    const auth = readAuth()
+    if (!auth?.sessionKey || !auth.scrobblingEnabled || !track?.artist || !track?.title) return
+
+    flushQueue(getQueuePath())
+
+    const timestamp = Math.floor(Date.now() / 1000)
+    const result = await scrobble(auth, auth.sessionKey, track, timestamp)
+    if (!result.ok) {
+      enqueueFailedScrobble(getQueuePath(), auth, auth.sessionKey, track, timestamp)
+    }
+  })
+}

--- a/src/backend/utils/lastfmClient.js
+++ b/src/backend/utils/lastfmClient.js
@@ -1,0 +1,125 @@
+import crypto from "node:crypto"
+import fs from "node:fs"
+
+const API_ENDPOINT = "https://ws.audioscrobbler.com/2.0/"
+const TIMEOUT_MS = 5000
+const MAX_QUEUE_SIZE = 50
+
+export function buildSignature(params, secret) {
+  const sorted = Object.keys(params)
+    .sort()
+    .map((key) => `${key}${params[key]}`)
+    .join("")
+  return crypto
+    .createHash("md5")
+    .update(sorted + secret, "utf8")
+    .digest("hex")
+}
+
+async function request({ apiKey, apiSecret }, method, params, { httpMethod = "GET" } = {}) {
+  const allParams = { ...params, method, api_key: apiKey }
+  const api_sig = buildSignature(allParams, apiSecret)
+  const body = new URLSearchParams({ ...allParams, api_sig, format: "json" })
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+  try {
+    const response =
+      httpMethod === "GET"
+        ? await fetch(`${API_ENDPOINT}?${body}`, { signal: controller.signal })
+        : await fetch(API_ENDPOINT, {
+            method: "POST",
+            body,
+            signal: controller.signal,
+          })
+
+    const data = await response.json()
+    if (!response.ok || data.error) {
+      return { ok: false, error: data.message || `http-${response.status}` }
+    }
+    return { ok: true, data }
+  } catch (err) {
+    return { ok: false, error: err.name === "AbortError" ? "timeout" : err.message }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export async function getToken(credentials) {
+  const result = await request(credentials, "auth.gettoken", {})
+  if (!result.ok) return result
+  return { ok: true, token: result.data.token }
+}
+
+export function buildAuthUrl({ apiKey }, token) {
+  return `https://www.last.fm/api/auth/?api_key=${apiKey}&token=${token}`
+}
+
+export async function getSession(credentials, token) {
+  const result = await request(credentials, "auth.getsession", { token })
+  if (!result.ok) return result
+  return {
+    ok: true,
+    sessionKey: result.data.session.key,
+    username: result.data.session.name,
+  }
+}
+
+export async function updateNowPlaying(credentials, sessionKey, { artist, title, album, duration }) {
+  const params = { artist, track: title, sk: sessionKey }
+  if (album) params.album = album
+  if (duration) params.duration = String(Math.round(duration))
+  return request(credentials, "track.updatenowplaying", params, { httpMethod: "POST" })
+}
+
+export async function scrobble(credentials, sessionKey, { artist, title, album, duration }, timestamp) {
+  const params = {
+    artist,
+    track: title,
+    timestamp: String(timestamp),
+    sk: sessionKey,
+  }
+  if (album) params.album = album
+  if (duration) params.duration = String(Math.round(duration))
+  return request(credentials, "track.scrobble", params, { httpMethod: "POST" })
+}
+
+// ponytail: local convenience queue, not a durable log — capped so an
+// extended offline stretch can't grow this file unbounded. queuePath is
+// passed in by the caller (main/lastfm.js knows the userData dir) so this
+// module has no electron dependency and stays unit-testable under plain node.
+function readQueue(queuePath) {
+  try {
+    return JSON.parse(fs.readFileSync(queuePath, "utf-8"))
+  } catch {
+    return []
+  }
+}
+
+function writeQueue(queuePath, queue) {
+  try {
+    fs.writeFileSync(queuePath, JSON.stringify(queue))
+  } catch (err) {
+    console.error("lastfm :: failed to persist retry queue:", err)
+  }
+}
+
+export function enqueueFailedScrobble(queuePath, credentials, sessionKey, track, timestamp) {
+  const queue = readQueue(queuePath)
+  queue.push({ credentials, sessionKey, track, timestamp })
+  while (queue.length > MAX_QUEUE_SIZE) queue.shift()
+  writeQueue(queuePath, queue)
+}
+
+export async function flushQueue(queuePath) {
+  const queue = readQueue(queuePath)
+  if (queue.length === 0) return
+
+  const remaining = []
+  for (const entry of queue) {
+    const result = await scrobble(entry.credentials, entry.sessionKey, entry.track, entry.timestamp)
+    if (!result.ok) remaining.push(entry)
+  }
+  writeQueue(queuePath, remaining)
+}

--- a/src/backend/utils/test_lastfmClient.mjs
+++ b/src/backend/utils/test_lastfmClient.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict"
+import crypto from "node:crypto"
+
+const {
+  buildSignature,
+  getToken,
+  getSession,
+  updateNowPlaying,
+  scrobble,
+} = await import("./lastfmClient.js")
+
+const credentials = { apiKey: "testkey", apiSecret: "testsecret" }
+const originalFetch = global.fetch
+
+// signature matches Last.fm's documented algorithm: sort keys, concat
+// key+value pairs, append secret, MD5.
+{
+  const params = { method: "auth.getsession", api_key: "testkey", token: "abc" }
+  const expected = crypto
+    .createHash("md5")
+    .update("api_keytestkeymethodauth.getsessiontokenabctestsecret", "utf8")
+    .digest("hex")
+  assert.equal(buildSignature(params, "testsecret"), expected)
+}
+
+// getToken success, signed with the caller's own credentials
+{
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({ token: "tok123" }),
+  })
+  const result = await getToken(credentials)
+  assert.equal(result.ok, true)
+  assert.equal(result.token, "tok123")
+}
+
+// getSession success
+{
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({ session: { key: "sk123", name: "testuser" } }),
+  })
+  const result = await getSession(credentials, "tok123")
+  assert.equal(result.ok, true)
+  assert.equal(result.sessionKey, "sk123")
+  assert.equal(result.username, "testuser")
+}
+
+// getSession failure (unauthorized token)
+{
+  global.fetch = async () => ({
+    ok: false,
+    status: 401,
+    json: async () => ({ error: 14, message: "Unauthorized Token" }),
+  })
+  const result = await getSession(credentials, "bad-token")
+  assert.equal(result.ok, false)
+  assert.equal(result.error, "Unauthorized Token")
+}
+
+// updateNowPlaying / scrobble send POST with signed params, using the
+// per-user credentials passed in rather than any shared app key
+{
+  let capturedBody
+  global.fetch = async (url, opts) => {
+    capturedBody = opts.body
+    return { ok: true, json: async () => ({}) }
+  }
+  await updateNowPlaying(credentials, "sk123", { artist: "A", title: "B", duration: 200 })
+  assert.ok(capturedBody.toString().includes("method=track.updatenowplaying"))
+  assert.ok(capturedBody.toString().includes("api_key=testkey"))
+  assert.ok(capturedBody.toString().includes("sk=sk123"))
+
+  await scrobble(credentials, "sk123", { artist: "A", title: "B" }, 1700000000)
+  assert.ok(capturedBody.toString().includes("method=track.scrobble"))
+  assert.ok(capturedBody.toString().includes("timestamp=1700000000"))
+}
+
+// network error surfaces as a non-ok result, not a throw
+{
+  global.fetch = async () => {
+    throw new Error("network down")
+  }
+  const result = await getToken(credentials)
+  assert.equal(result.ok, false)
+  assert.equal(result.error, "network down")
+}
+
+global.fetch = originalFetch
+console.log("lastfmClient self-check passed")

--- a/src/frontend/components/Setting.vue
+++ b/src/frontend/components/Setting.vue
@@ -185,6 +185,88 @@
                 </button>
               </div>
 
+              <div class="setting-group">
+                <div class="setting-label">
+                  <i class="fa-brands fa-lastfm"></i>
+                  <div>
+                    <h3>{{ t("settings.audio.lastfm.title") }}</h3>
+                    <p>{{ t("settings.audio.lastfm.description") }}</p>
+                  </div>
+                </div>
+
+                <template v-if="!lastfmStore.hasCredentials">
+                  <p class="section-description">
+                    {{ t("settings.audio.lastfm.credentialsHint") }}
+                    <a href="https://www.last.fm/api/account/create" target="_blank"
+                      >last.fm/api/account/create</a
+                    >
+                  </p>
+                  <input
+                    v-model="lastfmApiKey"
+                    type="text"
+                    class="lastfm-input"
+                    :placeholder="t('settings.audio.lastfm.apiKeyLabel')"
+                  />
+                  <input
+                    v-model="lastfmApiSecret"
+                    type="password"
+                    class="lastfm-input"
+                    :placeholder="t('settings.audio.lastfm.apiSecretLabel')"
+                  />
+                  <button
+                    class="theme-option"
+                    @click="lastfmStore.saveCredentials(lastfmApiKey, lastfmApiSecret)"
+                  >
+                    {{ t("settings.audio.lastfm.saveAndConnect") }}
+                  </button>
+                  <p v-if="lastfmStore.error" class="section-description">
+                    {{ t("settings.audio.lastfm.error", { error: lastfmStore.error }) }}
+                  </p>
+                </template>
+                <template v-else-if="!lastfmStore.connected">
+                  <button
+                    v-if="!lastfmStore.authPending"
+                    class="theme-option"
+                    @click="lastfmStore.connect()"
+                  >
+                    {{ t("settings.audio.lastfm.connect") }}
+                  </button>
+                  <template v-else>
+                    <p class="section-description">
+                      {{ t("settings.audio.lastfm.authorizeHint") }}
+                    </p>
+                    <button
+                      class="theme-option active"
+                      @click="lastfmStore.confirmAuth()"
+                    >
+                      {{ t("settings.audio.lastfm.confirm") }}
+                    </button>
+                  </template>
+                  <p v-if="lastfmStore.error" class="section-description">
+                    {{ t("settings.audio.lastfm.error", { error: lastfmStore.error }) }}
+                  </p>
+                </template>
+                <template v-else>
+                  <p class="section-description">
+                    {{ t("settings.audio.lastfm.connectedAs", { username: lastfmStore.username }) }}
+                  </p>
+                  <div class="theme-toggle">
+                    <button
+                      class="toggle-switch"
+                      :class="{ active: lastfmStore.scrobblingEnabled }"
+                      role="switch"
+                      :aria-checked="lastfmStore.scrobblingEnabled"
+                      @click="lastfmStore.toggleEnabled()"
+                    >
+                      <span class="toggle-knob"></span>
+                    </button>
+                    <button class="theme-option" @click="lastfmStore.disconnect()">
+                      {{ t("settings.audio.lastfm.disconnect") }}
+                    </button>
+                  </div>
+                </template>
+              </div>
+
               <div class="setting-group disabled">
                 <div class="setting-label">
                   <i class="fa-solid fa-sliders"></i>
@@ -298,6 +380,7 @@ import { ref, onMounted, computed } from "vue"
 import { useI18n } from "vue-i18n"
 import { useThemeStore } from "../store/theme.js"
 import { useAccentStore } from "../store/accent.js"
+import { useLastfmStore } from "../store/lastfm.js"
 
 const props = defineProps({
   showSettingMenu: {
@@ -309,6 +392,9 @@ const props = defineProps({
 const emit = defineEmits(["close"])
 const themeStore = useThemeStore()
 const accentStore = useAccentStore()
+const lastfmStore = useLastfmStore()
+const lastfmApiKey = ref("")
+const lastfmApiSecret = ref("")
 const { locale, t } = useI18n()
 
 const activeTab = ref("appearance")
@@ -376,6 +462,8 @@ onMounted(() => {
     currentLocale.value = savedLang
     locale.value = savedLang
   }
+
+  lastfmStore.fetchStatus()
 })
 </script>
 
@@ -589,6 +677,24 @@ onMounted(() => {
 
 .theme-option i {
   font-size: 1.25rem;
+}
+
+.lastfm-input {
+  display: block;
+  width: 100%;
+  max-width: 320px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  border: 2px solid var(--border-color);
+  background: var(--bg-color);
+  color: var(--text-color);
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.lastfm-input:focus {
+  outline: none;
+  border-color: var(--accent);
 }
 
 /* Toggle Switch */

--- a/src/frontend/store/lastfm.js
+++ b/src/frontend/store/lastfm.js
@@ -1,0 +1,76 @@
+import { defineStore } from "pinia"
+import { ref } from "vue"
+
+export const useLastfmStore = defineStore("lastfm", () => {
+  const hasCredentials = ref(false)
+  const connected = ref(false)
+  const username = ref(null)
+  const scrobblingEnabled = ref(false)
+  const authPending = ref(false)
+  const error = ref(null)
+
+  async function fetchStatus() {
+    const status = await window.api.lastfmGetStatus()
+    hasCredentials.value = status.hasCredentials
+    connected.value = status.connected
+    username.value = status.username
+    scrobblingEnabled.value = status.scrobblingEnabled
+  }
+
+  async function saveCredentials(apiKey, apiSecret) {
+    error.value = null
+    const result = await window.api.lastfmSaveCredentials(apiKey, apiSecret)
+    if (!result.ok) {
+      error.value = result.error
+      return
+    }
+    await fetchStatus()
+  }
+
+  async function connect() {
+    error.value = null
+    const result = await window.api.lastfmConnect()
+    if (!result.ok) {
+      error.value = result.error
+      return
+    }
+    authPending.value = true
+  }
+
+  async function confirmAuth() {
+    error.value = null
+    const result = await window.api.lastfmConfirmAuth()
+    if (!result.ok) {
+      error.value = result.error
+      return
+    }
+    authPending.value = false
+    await fetchStatus()
+  }
+
+  async function disconnect() {
+    await window.api.lastfmDisconnect()
+    authPending.value = false
+    await fetchStatus()
+  }
+
+  async function toggleEnabled() {
+    await window.api.lastfmSetEnabled(!scrobblingEnabled.value)
+    await fetchStatus()
+  }
+
+  return {
+    hasCredentials,
+    connected,
+    username,
+    scrobblingEnabled,
+    authPending,
+    error,
+    fetchStatus,
+    saveCredentials,
+    connect,
+    confirmAuth,
+    disconnect,
+    toggleEnabled,
+  }
+})

--- a/src/frontend/store/player.js
+++ b/src/frontend/store/player.js
@@ -27,6 +27,7 @@ export const usePlayerStore = defineStore("player", {
     progress: 0, // 0–1 normalized progress
     duration: 0, // total duration in seconds
     currentTime: 0, // current playback position
+    scrobbleSent: false, // whether the current play has already been scrobbled to Last.fm
     shuffleOrder: [], // shuffled indices
     originalOrder: [], // original order for restoring
   }),
@@ -40,6 +41,7 @@ export const usePlayerStore = defineStore("player", {
       const clonedTrack = { ...track } // Make a copy
       this.currentTrack = clonedTrack
       this.lyrics = null // Reset lyrics
+      this.scrobbleSent = false
       this.getLyrics() // Fire-and-forget, don't block playback start
       this.isPlaying = true
 
@@ -61,6 +63,16 @@ export const usePlayerStore = defineStore("player", {
 
       // Play track
       await this.playTrack(track.file_path)
+
+      // Last.fm now-playing update (fire-and-forget, no-op if not connected)
+      if (track.artist && track.title) {
+        window.api.lastfmNowPlaying({
+          artist: track.artist,
+          title: track.title,
+          album: track.album,
+          duration: track.duration,
+        })
+      }
 
       // Increment play count
       if (track.id) {
@@ -475,6 +487,20 @@ export const usePlayerStore = defineStore("player", {
           this.currentTime = Math.min(elapsed, currentAudioBuffer.duration)
           this.duration = currentAudioBuffer.duration
           this.progress = Math.min(this.currentTime / this.duration, 1)
+
+          // Last.fm scrobble rule: half the track or 4 minutes, whichever
+          // is lower, and only for tracks longer than 30s.
+          const { artist, title, album } = this.currentTrack
+          if (
+            !this.scrobbleSent &&
+            artist &&
+            title &&
+            this.duration > 30 &&
+            this.currentTime >= Math.min(this.duration / 2, 240)
+          ) {
+            this.scrobbleSent = true
+            window.api.lastfmScrobble({ artist, title, album, duration: this.duration })
+          }
         }
       }, 200)
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -154,6 +154,20 @@
         "title": "Fetch lyrics online",
         "description": "Automatically look up synced lyrics online when none are found locally"
       },
+      "lastfm": {
+        "title": "Last.fm Scrobbling",
+        "description": "Connect your Last.fm account to automatically scrobble what you play",
+        "credentialsHint": "Register a free API application at the link below (any application name works, e.g. \"EchoVault\" — the other fields can be left blank):",
+        "apiKeyLabel": "API Key",
+        "apiSecretLabel": "API Secret",
+        "saveAndConnect": "Save",
+        "connect": "Connect",
+        "authorizeHint": "Authorize EchoVault in the browser tab that just opened, then continue",
+        "confirm": "I've authorized, continue",
+        "error": "Couldn't connect: {error}",
+        "connectedAs": "Connected as {username}",
+        "disconnect": "Disconnect"
+      },
       "equalizer": {
         "title": "Equalizer",
         "description": "Adjust audio frequencies to your preference"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -156,6 +156,20 @@
         "title": "歌詞をオンラインで取得",
         "description": "ローカルで見つからない場合、同期歌詞をオンラインで自動検索します"
       },
+      "lastfm": {
+        "title": "Last.fm スクロビング",
+        "description": "Last.fm アカウントを連携して再生履歴を自動送信します",
+        "credentialsHint": "下記リンクから無料の API アプリケーションを登録してください(アプリケーション名は自由入力可、例:「EchoVault」— 他の項目は空欄で構いません):",
+        "apiKeyLabel": "API キー",
+        "apiSecretLabel": "API シークレット",
+        "saveAndConnect": "保存",
+        "connect": "連携する",
+        "authorizeHint": "開いたブラウザタブで EchoVault を承認してから続行してください",
+        "confirm": "承認しました、続行",
+        "error": "接続に失敗しました: {error}",
+        "connectedAs": "{username} として接続中",
+        "disconnect": "連携解除"
+      },
       "equalizer": {
         "title": "イコライザ",
         "description": "音域を調整して好みの音にします"

--- a/src/preload.js
+++ b/src/preload.js
@@ -76,4 +76,15 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.invoke("delete-playlist", playlistId),
   updatePlaylist: (playlistId, name) =>
     ipcRenderer.invoke("update-playlist", playlistId, name),
+
+  // last.fm
+  lastfmGetStatus: () => ipcRenderer.invoke("lastfm:get-status"),
+  lastfmSaveCredentials: (apiKey, apiSecret) =>
+    ipcRenderer.invoke("lastfm:save-credentials", { apiKey, apiSecret }),
+  lastfmConnect: () => ipcRenderer.invoke("lastfm:connect"),
+  lastfmConfirmAuth: () => ipcRenderer.invoke("lastfm:confirm-auth"),
+  lastfmDisconnect: () => ipcRenderer.invoke("lastfm:disconnect"),
+  lastfmSetEnabled: (enabled) => ipcRenderer.invoke("lastfm:set-enabled", enabled),
+  lastfmNowPlaying: (track) => ipcRenderer.invoke("lastfm:now-playing", track),
+  lastfmScrobble: (track) => ipcRenderer.invoke("lastfm:scrobble", track),
 })


### PR DESCRIPTION
Lets users connect a Last.fm account from Settings and automatically scrobble what they play. Each user registers their own free Last.fm API application and pastes the key/secret into Settings rather than the app embedding one shared app-wide secret in the binary — avoids shipping a signing secret that could be extracted from the build.

Session key and API credentials are encrypted at rest via Electron safeStorage and never exposed to the renderer. Now-playing/scrobble triggers hook into the existing playback progress loop, matching Last.fm's scrobble rule (50% played or 4 minutes, tracks over 30s). Failed scrobbles are queued and retried on the next successful call.